### PR TITLE
Modernize project

### DIFF
--- a/cli/config.rs
+++ b/cli/config.rs
@@ -1,9 +1,10 @@
-use super::Error;
-use super::Result;
+use super::{Error, Result};
 use helium_console::client::Config;
-use std::fs;
-use std::io::{stdin, Write};
-use std::path::Path;
+use std::{
+    fs,
+    io::{stdin, Write},
+    path::Path,
+};
 use toml;
 
 pub fn get_input(prompt: &str) -> String {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -231,7 +231,7 @@ async fn ttn_import() -> Result {
                             Some(device)
                         }
                         Err(err) => {
-                            println!("{}", err.description());
+                            println!("{}", err);
                             if let Some(error) = err.downcast_ref::<Error>() {
                                 match error {
                                     Error::NewDevice422 => {
@@ -255,8 +255,7 @@ async fn ttn_import() -> Result {
                             UserResponse::Yes => true,
                             UserResponse::No => false,
                             UserResponse::Maybe => {
-                                let first_answer =
-                                    get_input(format!("Add label to device?").as_str());
+                                let first_answer = get_input("Add label to device?");
                                 let answer = yes_or_no(first_answer, Some("Please type y or n"));
                                 match answer {
                                     UserResponse::Yes => true,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,10 +1,4 @@
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-#[macro_use]
-extern crate prettytable;
-
-use prettytable::Table;
+use prettytable::{cell, row, Table};
 use std::process;
 use structopt::StructOpt;
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,5 +1,5 @@
 use prettytable::{cell, row, Table};
-use std::process;
+use std::{process, str::FromStr};
 use structopt::StructOpt;
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -12,7 +12,6 @@ mod ttn;
 use clicmd::*;
 use config::get_input;
 use helium_console::*;
-use std::str::FromStr;
 
 /// Interact with Helium API via CLI
 #[derive(StructOpt, Debug)]

--- a/cli/ttn.rs
+++ b/cli/ttn.rs
@@ -51,7 +51,7 @@ impl Client {
             )?)),
         );
         let access_code = get_input("Provide a single use ttnctl access code");
-        let code = AuthorizationCode::new(access_code.to_string());
+        let code = AuthorizationCode::new(access_code);
         let token_res = client.exchange_code(code).unwrap();
         Ok(token_res.access_token().clone())
     }
@@ -69,8 +69,7 @@ impl Client {
     }
 
     pub async fn get_apps(&self, token: &AccessToken) -> Result<Vec<App>> {
-        let request =
-            self.get_with_token(&token.secret(), format!("/api/v2/applications").as_str());
+        let request = self.get_with_token(&token.secret(), "/api/v2/applications");
         let response = request.send().await?;
         let body = response.text().await.unwrap();
         let apps: Vec<App> = serde_json::from_str(&body)?;
@@ -97,7 +96,7 @@ impl Client {
         Ok(token_response.access_token)
     }
 
-    pub async fn get_devices(&self, app: &App, token: &String) -> Result<Vec<TtnDevice>> {
+    pub async fn get_devices(&self, app: &App, token: &str) -> Result<Vec<TtnDevice>> {
         // We brute force going through handler URLs
         for url in &APP_BASE_URL {
             let request = self

--- a/cli/ttn.rs
+++ b/cli/ttn.rs
@@ -1,10 +1,11 @@
 use super::config::get_input;
 use super::Result;
 use helium_console::NewDeviceRequest;
-use oauth2::basic::BasicClient;
-use oauth2::prelude::*;
-use oauth2::AccessToken;
-use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, TokenResponse, TokenUrl};
+use oauth2::{
+    basic::BasicClient,
+    prelude::{NewType, SecretNewType},
+    AccessToken, AuthUrl, AuthorizationCode, ClientId, ClientSecret, TokenResponse, TokenUrl,
+};
 use reqwest::Client as ReqwestClient;
 use serde_derive::{Deserialize, Serialize};
 use std::time::Duration;

--- a/cli/ttn.rs
+++ b/cli/ttn.rs
@@ -4,6 +4,7 @@ extern crate url;
 
 use super::config::get_input;
 use super::Result;
+use helium_console::NewDeviceRequest;
 use oauth2::basic::BasicClient;
 use oauth2::prelude::*;
 use oauth2::AccessToken;
@@ -11,7 +12,6 @@ use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, TokenResponse, 
 use reqwest::Client as ReqwestClient;
 use std::time::Duration;
 use url::Url;
-use helium_console::NewDeviceRequest;
 
 const ACCOUNT_BASE_URL: &str = "https://account.thethingsnetwork.org";
 

--- a/cli/ttn.rs
+++ b/cli/ttn.rs
@@ -1,7 +1,3 @@
-extern crate base64;
-extern crate oauth2;
-extern crate url;
-
 use super::config::get_input;
 use super::Result;
 use helium_console::NewDeviceRequest;
@@ -10,6 +6,7 @@ use oauth2::prelude::*;
 use oauth2::AccessToken;
 use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, TokenResponse, TokenUrl};
 use reqwest::Client as ReqwestClient;
+use serde_derive::{Deserialize, Serialize};
 use std::time::Duration;
 use url::Url;
 

--- a/lib/client.rs
+++ b/lib/client.rs
@@ -1,5 +1,3 @@
-use super::Error;
-use super::Result;
 use super::*;
 use base64;
 use reqwest::Client as ReqwestClient;

--- a/lib/client.rs
+++ b/lib/client.rs
@@ -52,7 +52,7 @@ impl Client {
 
         Ok(Client {
             base_url: config.base_url.clone(),
-            key: config.key.clone(),
+            key: config.key,
             client,
             labels: HashMap::new(),
         })
@@ -104,7 +104,7 @@ impl Client {
         Ok(devices)
     }
 
-    pub async fn get_device_by_id(&self, id: &String) -> Result<Device> {
+    pub async fn get_device_by_id(&self, id: &str) -> Result<Device> {
         let request = self.get(format!("api/v1/devices/{}", id).as_str())?;
         let response = request.send().await?;
         let body = response.text().await.unwrap();
@@ -126,7 +126,7 @@ impl Client {
         }
     }
 
-    pub async fn delete_device(&self, id: &String) -> Result<()> {
+    pub async fn delete_device(&self, id: &str) -> Result<()> {
         let request = self.delete(format!("api/v1/devices/{}", id).as_str())?;
         let response = request.send().await?;
         if response.status() == 200 {
@@ -165,7 +165,7 @@ impl Client {
         }
     }
 
-    pub async fn delete_label(&self, id: &String) -> Result<()> {
+    pub async fn delete_label(&self, id: &str) -> Result<()> {
         let request = self.delete(format!("api/v1/labels/{}", id).as_str())?;
         let response = request.send().await?;
         if response.status() == 200 {
@@ -204,11 +204,11 @@ impl Client {
         Ok(())
     }
 
-    pub async fn get_label_uuid(&mut self, device_label: &String) -> Result<String> {
-        let label_upper = device_label.clone().to_uppercase();
+    pub async fn get_label_uuid(&mut self, device_label: &str) -> Result<String> {
+        let label_upper = device_label.to_uppercase();
 
         // we probably haven't fetched labels if length is 0
-        if self.labels.len() == 0 {
+        if self.labels.is_empty() {
             self.get_labels().await?;
         }
 

--- a/lib/errors.rs
+++ b/lib/errors.rs
@@ -1,4 +1,3 @@
-use std::error::Error as stdError;
 use std::{fmt, str};
 
 #[derive(Debug, Clone)]
@@ -54,7 +53,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl stdError for Error {
+impl ::std::error::Error for Error {
     fn description(&self) -> &str {
         match self {
             Error::InvalidAppEui => "Invalid AppEui input. Must be 8 bytes represented in hex (\"0123456789ABCDEF\")",

--- a/lib/errors.rs
+++ b/lib/errors.rs
@@ -16,40 +16,39 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
+        let msg = match self {
             Error::InvalidAppEui => {
-                write!(f, "Invalid AppEui input. Must be 8 bytes represented in hex (\"0123456789ABCDEF\")")
+                "Invalid AppEui input. Must be 8 bytes represented in hex (\"0123456789ABCDEF\")"
             }
             Error::InvalidAppKey => {
-                write!(f, "Invalid AppKey input. Must be 16 bytes represented in hex (\"0123456789ABCDEF0123456789ABCDEF\")")
+                "Invalid AppKey input. Must be 16 bytes represented in hex (\"0123456789ABCDEF0123456789ABCDEF\")"
             }
             Error::InvalidDevEui => {
-                write!(f, "Invalid DevEui input. Must be 8 bytes represented in hex (\"0123456789ABCDEF\")")
+                "Invalid DevEui input. Must be 8 bytes represented in hex (\"0123456789ABCDEF\")"
             }
             Error::InvalidApiKey => {
-                write!(f, "Invalid Api Key. Must be 32 bytes represented in base64")
+                "Invalid Api Key. Must be 32 bytes represented in base64"
             }
             Error::InvalidUuid => {
-                write!(f, "Invalid UUID input. Expected in hyphenated form \"00000000-0000-0000-0000-000000000000\"")
+                "Invalid UUID input. Expected in hyphenated form \"00000000-0000-0000-0000-000000000000\""
             }
             Error::NewDevice422 => {
-                write!(f, "Failed Creating Device! Device with identical credentials already exists")
+                "Failed Creating Device! Device with identical credentials already exists"
             }
             Error::NewDeviceApi => {
-                write!(f, "Failed Creating Device! Unknown server error")
+                "Failed Creating Device! Unknown server error"
             }
             Error::NewLabel422 => {
-                write!(f, "Failed Creating Label! Label with same name already exists under organization")
+                "Failed Creating Label! Label with same name already exists under organization"
             }
             Error::NewLabelApi => {
-                write!(f, "Failed Creating Label! Unknown server error")
+                "Failed Creating Label! Unknown server error"
             }
             Error::NewDeviceLabelApi => {
-                write!(f, "Failed Creating Device Label! Unknown server error")
+                "Failed Creating Device Label! Unknown server error"
             }
-
-
-        }
+        };
+        write!(f, "{}", msg)
     }
 }
 
@@ -62,7 +61,7 @@ impl ::std::error::Error for Error {
             Error::InvalidApiKey => "Invalid Api Key. Must be 32 bytes represented in base64",
             Error::InvalidUuid => "Invalid UUID input. Expected in hyphenated form \"00000000-0000-0000-0000-000000000000\"",
             Error::NewDevice422 => "Failed Creating Device! Device with identical credentials already exists",
-            Error::NewDeviceApi => "Failed Creating Device! Unknown server error", 
+            Error::NewDeviceApi => "Failed Creating Device! Unknown server error",
             Error::NewLabel422 => "Failed Creating Label! Label with same name already exists under organization",
             Error::NewLabelApi => "Failed Creating Label! Unknown server error",
             Error::NewDeviceLabelApi => "Failed Creating Device Label! Unknown server error",

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -134,10 +134,10 @@ pub struct NewLabelRequest {
 }
 
 impl NewLabelRequest {
-    pub fn from_string(string: &String) -> NewLabelRequest {
+    pub fn from_string(string: &str) -> NewLabelRequest {
         NewLabelRequest {
             label: LabelRequest {
-                name: string.clone(),
+                name: string.to_owned(),
             },
         }
     }
@@ -178,8 +178,8 @@ impl DeviceLabel {
 }
 
 /// Throws an error if UUID isn't properly input
-pub fn validate_uuid_input(id: &String) -> Result {
-    if let Err(err) = uuid::Uuid::parse_str(id.as_str()) {
+pub fn validate_uuid_input(id: &str) -> Result {
+    if let Err(err) = uuid::Uuid::parse_str(id) {
         println!("{} [input: {}]", err, id);
         return Err(Error::InvalidUuid.into());
     }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
+use serde_derive::{Deserialize, Serialize};
 
 pub mod client;
 pub mod errors;
-
 pub use errors::*;
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;


### PR DESCRIPTION
This PR is mix-match of cleanups, in the following order:

1. format code
1. fix all Clippy warnings
1. use 2018-style `use` expressions which do not require `extern crate`

This was mostly a mechanical effort; further cleanup would require a deeper understanding of the code.

## TODO

I wasn't planning on doing it now, but It's a good idea to add `clippy` and `rustfmt` as CI build steps to prevent messy diffs later on.
