### PR TITLE
Add "devices all" for detailed listing; includes `in_xor_filter` status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ When installer is complete, select C++ Build Tools from the tile menu, use defau
 
 ## How to use
 
-Docs for users of the Console CLI are available [here](https://developer.helium.com/console/cli)
+Docs for users of the Console CLI are available [here](https://docs.helium.com/use-the-network/console/cli/)

--- a/cli/clicmd.rs
+++ b/cli/clicmd.rs
@@ -61,6 +61,13 @@ pub enum DeviceCmd {
 }
 
 #[derive(StructOpt, Debug)]
+pub enum DevicesCmd {
+    // No arguments required, but added for consistency
+    // and to disambiguate from `help`
+    All,
+}
+
+#[derive(StructOpt, Debug)]
 pub enum LabelCmd {
     /// List all your organization's labels
     List,

--- a/lib/client.rs
+++ b/lib/client.rs
@@ -79,6 +79,22 @@ impl Client {
             .header("key", self.key.as_str()))
     }
 
+    pub async fn get_detailed_devices(&self) -> Result<Vec<DetailedDevice>> {
+        let request = self.get("api/v1/devices")?;
+        let response = request.send().await?;
+        if response.status() == 200 {
+            let body = response.text().await.unwrap();
+            let devices: Vec<DetailedDevice> = serde_json::from_str(&body)?;
+            Ok(devices)
+        } else if response.status() == 401 {
+            let body = response.text().await.unwrap();
+            println!("{}", body);
+            Err(Error::UnauthorizedApi.into())
+        } else {
+            Err(Error::HttpErrorApi.into())
+        }
+    }
+
     pub async fn get_devices(&self) -> Result<Vec<Device>> {
         let request = self.get("api/v1/devices")?;
         let response = request.send().await?;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -204,3 +204,26 @@ pub fn validate_uuid_input(id: &str) -> Result {
     }
     Ok(())
 }
+
+#[derive(Clone, Deserialize, Serialize, Debug)]
+pub struct DetailedDevice {
+    app_eui: String,
+    app_key: String,
+    dev_eui: String,
+    id: String,
+    name: String,
+    organization_id: String,
+    oui: usize,
+
+    // Extended set beyond fields in `Device`
+    active: bool,
+    adr_allowed: serde_json::Value,
+    cf_list_enabled: serde_json::Value,
+    config_profile_id: serde_json::Value,
+    dc_usage: usize,
+    in_xor_filter: bool,
+    labels: Vec<String>,
+    last_connected: serde_json::Value,
+    rx_delay: u8,
+    total_packets: usize,
+}

--- a/lib/ttn.rs
+++ b/lib/ttn.rs
@@ -73,7 +73,7 @@ impl Client {
     }
 
     pub async fn get_apps(&self, token: &AccessToken) -> Result<Vec<App>> {
-        let request = self.get_with_token(&token.secret(), "/api/v2/applications");
+        let request = self.get_with_token(token.secret(), "/api/v2/applications");
         let response = request.send().await?;
         let body = response.text().await.unwrap();
         let apps: Vec<App> = serde_json::from_str(&body)?;


### PR DESCRIPTION
While `device list` command existed, this adds `devices` which is a separate API command that yields more details per device.

- Was necessary for obtaining status of XOR filter for a device
- `struct DetailedDevice` is modeled after `struct Device` since it's only adds fields
- For keeping code consistent, a superfluous operator was added
  + makes the CLI argument: `devices all`
  + also disambiguates against `devices help`
- The patch to `lib/ttn.rs` is based upon Clippy
- Useful addition to automating Load & Capacity tests, [router#677](https://github.com/helium/router/issues/677)
