### PR TITLE
Lock stdout for large writes

### DIFF
--- a/cli/config.rs
+++ b/cli/config.rs
@@ -30,7 +30,7 @@ pub fn load(path: &str) -> Result<Config> {
 
         let config = Config::new(key);
 
-        file.write_all(&toml::to_string(&config)?.as_bytes())?;
+        file.write_all(toml::to_string(&config)?.as_bytes())?;
     }
 
     let contents = fs::read_to_string(path)?;


### PR DESCRIPTION
- Addresses helpful feedback from previous PR; thanks, Jay!
- With benchmark runs of 1k devices per organization and multiple organizations, this performance boost will be appreciated
- This is more idiomatic Rust
- The change to `config.rs` was recommended by Clippy